### PR TITLE
Add command argument to switchbot_py3.py

### DIFF
--- a/switchbot_py3.py
+++ b/switchbot_py3.py
@@ -74,6 +74,9 @@ def main():
     parser.add_argument('--interface', '-i', dest='interface', required=False, default=None,
                         help="Name of the bluetooth adapter (default: hci0 or whichever is the default)")
 
+    parser.add_argument('--command', '-c', dest='command', required=False, default='press',
+                        choices=['press', 'on', 'off'], help="Command to be sent to device (default: press)")
+
     opts, args = parser.parse_known_args(sys.argv[1:])
 
     if opts.scan:
@@ -101,7 +104,7 @@ def main():
     driver.connect()
     print('Connected!')
 
-    driver.run_command('press')
+    driver.run_command(opts.command)
     print('Command execution successful')
 
 


### PR DESCRIPTION
New argument for switchbot_py3.py:
--command or -c to specify command to be sent to device.
The default value is `press`, therefore it works as same as before it no command is given.