### PR TITLE
Fix motion sensor light status read wrong bits

### DIFF
--- a/switchbot.py
+++ b/switchbot.py
@@ -106,7 +106,7 @@ class DevScanner(DefaultDelegate):
                         # print(adtype, desc, value)
                         pirSta = (
                             int(value[6:7].encode('utf-8'), 16) >> 2) & 0x01
-                        lightSta = (int(value[13:14].encode('utf-8'), 16) & 0x03) - 1
+                        lightSta = (int(value[15:16].encode('utf-8'), 16) & 0x03) - 1
                         # TODO:
                         diffSec = 0
                         param_list.extend([pirSta, lightSta, diffSec])

--- a/switchbot_py2topy3.py
+++ b/switchbot_py2topy3.py
@@ -106,7 +106,7 @@ class DevScanner(DefaultDelegate):
                         # print(adtype, desc, value)
                         pirSta = (
                             int(value[6:7].encode('utf-8'), 16) >> 2) & 0x01
-                        lightSta = (int(value[13:14].encode('utf-8'), 16) & 0x03) - 1
+                        lightSta = (int(value[15:16].encode('utf-8'), 16) & 0x03) - 1
                         # TODO:
                         diffSec = 0
                         param_list.extend([pirSta, lightSta, diffSec])


### PR DESCRIPTION
Hello.

I tried to use a 'Motion Sensor', but it would not work.

According to [Motion Sensor BLE](https://github.com/OpenWonderLabs/python-host/wiki/Motion-Sensor-BLE-open-API#motion-sensor-broadcast-message), the light staus is in 5byte [0:1]bits.

Howerver, your code reads `value[13:14]` which means 4byte [0:1]bits.

Please check my fix. 
Thank you.
 

 
